### PR TITLE
chore: Improvements in tool flow

### DIFF
--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using UnityEditor;
+using UnityEngine;
+
+namespace StansAssets.SceneManagement.Build
+{
+    [InitializeOnLoad]
+    public class BuildConfigurationSettingsValidator
+    {
+        public class ValidationReport
+        {
+            public Dictionary<BuildConfiguration, ConfigurationValidationData> ConfigurationReports = new Dictionary<BuildConfiguration, ConfigurationValidationData>();
+        }
+
+        public class ConfigurationValidationData
+        {
+            public List<AddressableSceneAsset> Duplicates = new List<AddressableSceneAsset>();
+            public int MissingScenesCounter;
+        }
+
+        public const string TAG = "[Build Configuration]";
+
+        static BuildConfigurationSettingsValidator() {
+            ValidateConfiguration();
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        static void OnPlayModeStateChanged(PlayModeStateChange state) {
+            switch (state) {
+                case PlayModeStateChange.EnteredPlayMode:
+                    BuildConfigurationSettings.Instance.Configuration.SetupBuildSettings(EditorUserBuildSettings.activeBuildTarget);
+                    break;
+            }
+        }
+
+        static void ValidateConfiguration(bool printWarnings = true) {
+            if (BuildConfigurationSettings.Instance == null) {
+                throw new DataException("BuildConfigurationSettings is null!");
+            }
+
+            if (BuildConfigurationSettings.Instance.HasValidConfiguration) {
+                foreach (var configuration in BuildConfigurationSettings.Instance.BuildConfigurations) {
+                    HashSet<string> sceneGuids = new HashSet<string>();
+                    foreach (var platformConfiguration in configuration.Platforms) {
+                        ValidateScenes(platformConfiguration.Scenes, configuration, printWarnings, sceneGuids);
+                    }
+
+                    ValidateScenes(configuration.DefaultScenes, configuration, printWarnings, sceneGuids);
+                }
+
+                BuildConfigurationSettings.Instance.Configuration.SetupBuildSettings(EditorUserBuildSettings.activeBuildTarget);
+            }
+        }
+
+        static void ValidateScenes(IEnumerable<AddressableSceneAsset> scenes, BuildConfiguration configuration, bool printWarnings, HashSet<string> sceneGuids) {
+            foreach (var scene in scenes) {
+                var sceneAsset = scene.GetSceneAsset();
+                if (sceneAsset == null) {
+                    if(printWarnings)
+                        Debug.LogWarning($"{TAG} Scene is missing in configuration: {configuration.Name}");
+                }
+                else if (sceneGuids.Contains(scene.Guid)) {
+                    if(printWarnings)
+                        Debug.LogWarning($"{TAG} Scene: {sceneAsset.name} duplicated in configuration: {configuration.Name}");
+                }
+                else {
+                    sceneGuids.Add(scene.Guid);
+                }
+            }
+        }
+
+        ConfigurationValidationData GetValidationDataFor(BuildConfiguration configuration, ValidationReport report) {
+            if (report.ConfigurationReports.TryGetValue(configuration, out var data) == false) {
+                data = new ConfigurationValidationData();
+                report.ConfigurationReports[configuration] = data;
+            }
+
+            return data;
+        }
+    }
+}

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs.meta
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94db12918a8f4de8af2a20403bf0f090
+timeCreated: 1602191991

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Build;
 using UnityEditor.AddressableAssets.Settings;
@@ -30,7 +31,7 @@ namespace StansAssets.SceneManagement.Build
                 SetupBuildOptions(ref options);
                 EditorApplication.delayCall += () =>
                 {
-                    Debug.Log("Scenes list " + string.Join(", \n", options.scenes));
+                    Debug.Log("Scenes list:\n" + string.Join(", \n", options.scenes));
                     BuildPlayerWindow.DefaultBuildMethods.BuildPlayer(options);
                 };
             });
@@ -54,86 +55,24 @@ namespace StansAssets.SceneManagement.Build
 
         static string[] FilterScenesByPath(BuildTarget target, string[] buildScenes)
         {
-            var configuration = BuildConfigurationSettings.Instance.Configuration;
-            if (configuration.IsEmpty)
+            if (BuildConfigurationSettings.Instance.HasValidConfiguration == false)
             {
                 return buildScenes;
             }
 
-            List<string> scenes = new List<string>();
-
-            var defaultNonAddrScenes = configuration.GetNonAddressableDefaultScenes();
-            if (defaultNonAddrScenes.Count == 0)
-            {
-                scenes.AddRange(buildScenes);
-                ProcessPlatforms(ref scenes, target, configuration.Platforms);
-            }
-            else
-            {
-                if (configuration.DefaultScenesFirst)
-                {
-                    ProcessPlatforms(ref scenes, target, configuration.Platforms);
-                    InsertScenes(ref scenes, defaultNonAddrScenes);
-                }
-                else
-                {
-                    InsertScenes(ref scenes, defaultNonAddrScenes);
-                    ProcessPlatforms(ref scenes, target, configuration.Platforms);
-                }
-            }
-
-            return scenes.ToArray();
-        }
-
-        static void ProcessPlatforms(ref List<string> scenes, BuildTarget target, List<PlatformsConfiguration> platforms)
-        {
-            foreach (var platformsConfiguration in platforms)
-            {
-                var editorBuildTargets = platformsConfiguration.GetBuildTargetsEditor();
-                if (editorBuildTargets.Contains(target))
-                {
-                    InsertScenes(ref scenes, platformsConfiguration.GetNonAddressableScenes());
-                }
-                else
-                {
-                    RemoveScenes(ref scenes, platformsConfiguration.GetNonAddressableScenes());
-                }
-                // Remove any addressable scene from a build
-                RemoveScenes(ref scenes, platformsConfiguration.GetAddressableScenes());
-            }
-        }
-
-        static void InsertScenes(ref List<string> scenes, List<SceneAsset> sceneAssets)
-        {
-            for (var index = 0; index < sceneAssets.Count; index++)
-            {
-                var sceneAssetPath = AssetDatabase.GetAssetPath(sceneAssets[index]);
-                if (string.IsNullOrEmpty(sceneAssetPath))
-                    continue;
-
-                if (scenes.Contains(sceneAssetPath))
-                {
-                    scenes.Remove(sceneAssetPath);
-                }
-
-                scenes.Insert(index, sceneAssetPath);
-            }
-        }
-
-        static void RemoveScenes(ref List<string> scenes, List<SceneAsset> sceneAssets)
-        {
-            foreach (var sceneAsset in sceneAssets)
-            {
-                var sceneAssetPath = AssetDatabase.GetAssetPath(sceneAsset);
-                if (scenes.Contains(sceneAssetPath))
-                {
-                    scenes.Remove(sceneAssetPath);
-                }
-            }
+            var configuration = BuildConfigurationSettings.Instance.Configuration;
+            var sceneAssets = configuration.BuildScenesCollection(target, true);
+            var scenes = sceneAssets.Select(s => AssetDatabase.GUIDToAssetPath(s.Guid)).ToArray();
+            return scenes;
         }
 
         static void SetupAddressableScenes(BuildTarget target) {
-            InitializeAddressablesAPI();
+            if (BuildConfigurationSettings.Instance.HasValidConfiguration == false)
+            {
+                return;
+            }
+
+            InitializeAddressablesSettings();
             // TODO: Don't create a group until we checked that even 1 scene is Addressable
             var group = AddressablesUtility.GetOrCreateGroup(ScenesAddressablesGroupName);
             var configuration = BuildConfigurationSettings.Instance.Configuration;
@@ -172,12 +111,12 @@ namespace StansAssets.SceneManagement.Build
             {
                 AddressableAssetSettingsDefaultObject.Settings.RemoveGroup(group);
             }
-            BuildConfigurationSettings.Instance.Configuration.InitializeBuildData((BuildTargetRuntime)(int)target);
+            BuildConfigurationSettings.Instance.Configuration.InitializeBuildData(target);
             EditorUtility.SetDirty(BuildConfigurationSettings.Instance);
             AssetDatabase.SaveAssets();
         }
 
-        static void InitializeAddressablesAPI() {
+        static void InitializeAddressablesSettings() {
             if (AddressableAssetSettingsDefaultObject.Settings == null) {
                 AddressableAssetSettingsDefaultObject.Settings = AddressableAssetSettings.Create(AddressableAssetSettingsDefaultObject.kDefaultConfigFolder,
                                                                                                  AddressableAssetSettingsDefaultObject.kDefaultConfigAssetName,

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/AddressableSceneAssetExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/AddressableSceneAssetExtension.cs
@@ -24,6 +24,9 @@ namespace StansAssets.SceneManagement.Build
                 var guid = AssetDatabase.AssetPathToGUID(path);
                 addressableSceneAsset.Guid = guid;
             }
+            else {
+                addressableSceneAsset.Guid = string.Empty;
+            }
         }
     }
 }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
@@ -8,56 +8,142 @@ namespace StansAssets.SceneManagement.Build
 {
     static class BuildConfigurationExtension
     {
-        public static List<SceneAsset> GetAddressableDefaultScenes(this BuildConfiguration platformsConfiguration)
+        public static List<SceneAsset> GetAddressableDefaultScenes(this BuildConfiguration configuration)
         {
-            return platformsConfiguration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
+            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
         }
 
-        public static List<SceneAsset> GetNonAddressableDefaultScenes(this BuildConfiguration platformsConfiguration)
+        public static List<SceneAsset> GetNonAddressableDefaultScenes(this BuildConfiguration configuration)
         {
-            return platformsConfiguration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
+            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
         }
 
-        public static void InitializeBuildData(this BuildConfiguration platformsConfiguration, BuildTargetRuntime builtTarget)
+        public static void InitializeBuildData(this BuildConfiguration configuration, BuildTarget buildTarget)
         {
-            var sceneNames =  new List<string>();
-            var sceneAssets = new List<AddressableSceneAsset>();
+            var addressableSceneNames =  new List<string>();
+            var addressableSceneAssets = new List<AddressableSceneAsset>();
+            var allSceneNames = new List<string>();
 
-            foreach (var scene in platformsConfiguration.DefaultScenes)
-            {
-                if (scene.Addressable)
-                {
-                    string path = AssetDatabase.GUIDToAssetPath(scene.Guid);
-                    if (string.IsNullOrEmpty(path))
-                        continue;
+            var allSceneAssets = BuildScenesCollection(configuration, buildTarget, false);
+            foreach (var scene in allSceneAssets) {
+                string path = AssetDatabase.GUIDToAssetPath(scene.Guid);
+                if (string.IsNullOrEmpty(path))
+                    continue;
 
-                    sceneNames.Add(Path.GetFileNameWithoutExtension(path));
-                    sceneAssets.Add(scene);
+                string sceneName = Path.GetFileNameWithoutExtension(path);
+                allSceneNames.Add(sceneName);
+                if (scene.Addressable) {
+                    addressableSceneNames.Add(sceneName);
+                    addressableSceneAssets.Add(scene);
                 }
             }
 
-            foreach (var platform in platformsConfiguration.Platforms)
-            {
-                if (platform.BuildTargets.Contains(builtTarget))
-                {
-                    foreach (var scene in platform.Scenes)
-                    {
-                        if (scene.Addressable)
-                        {
-                            string path = AssetDatabase.GUIDToAssetPath(scene.Guid);
-                            if (string.IsNullOrEmpty(path))
-                                continue;
+            Debug.Log("Addressable Scenes: " + addressableSceneNames.Count);
+            Debug.Log($"Addressable Scenes List:\n{string.Join("\n", addressableSceneAssets.Select(asset => AssetDatabase.GUIDToAssetPath(asset.Guid)))}");
+            configuration.SetScenesConfig(addressableSceneNames, addressableSceneAssets, allSceneNames);
+        }
 
-                            sceneNames.Add(Path.GetFileNameWithoutExtension(path));
-                            sceneAssets.Add(scene);
-                        }
+        public static List<AddressableSceneAsset> BuildScenesCollection(this BuildConfiguration configuration, BuildTarget builtTarget, bool stripAddressables) {
+            var scenes = new List<AddressableSceneAsset>();
+
+            List<AddressableSceneAsset> defaultSceneAssets = stripAddressables ? configuration.DefaultScenes.Where(s => !s.Addressable).ToList()
+                                                                                      : configuration.DefaultScenes;
+
+            if (configuration.DefaultScenesFirst)
+            {
+                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables);
+                InsertScenes(ref scenes, defaultSceneAssets);
+            }
+            else
+            {
+                InsertScenes(ref scenes, defaultSceneAssets);
+                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables);
+            }
+
+            return scenes;
+        }
+
+        public static bool IsActive(this BuildConfiguration configuration, PlatformsConfiguration platformsConfiguration) {
+            BuildTargetRuntime buildTarget = (BuildTargetRuntime)(int)EditorUserBuildSettings.activeBuildTarget;
+            return platformsConfiguration.BuildTargets.Contains(buildTarget);
+        }
+
+        public static int GetSceneIndex(this BuildConfiguration configuration, AddressableSceneAsset scene) {
+            int platformScenesCount = 0;
+            foreach (var platformConfiguration in configuration.Platforms) {
+                if (IsActive(configuration, platformConfiguration)) {
+                    var platformIndex = platformConfiguration.Scenes.IndexOf(scene);
+                    if (platformIndex >= 0) {
+                        return configuration.DefaultScenesFirst ? configuration.DefaultScenes.Count + platformIndex : platformIndex;
                     }
+
+                    platformScenesCount = platformConfiguration.Scenes.Count;
                 }
             }
 
-            Debug.Log("Addressable Scenes: " + sceneNames.Count);
-            Debug.Log($"Addressable Scenes List:\n{string.Join("\n", sceneAssets.Select(asset => AssetDatabase.GUIDToAssetPath(asset.Guid)))}");
-            platformsConfiguration.SetScenesConfig(sceneNames, sceneAssets);
+            var defaultIndex = configuration.DefaultScenes.IndexOf(scene);
+            if (defaultIndex >= 0) {
+                return configuration.DefaultScenesFirst ? defaultIndex : defaultIndex + platformScenesCount;
+            }
+
+            return -1;
+        }
+
+        public static void SetupBuildSettings(this BuildConfiguration configuration, BuildTarget buildTarget) {
+            var buildSettingsScenes = EditorBuildSettings.scenes.ToList();
+            var buildSettingsSceneGuids = new HashSet<string>(buildSettingsScenes.Select(s => s.guid.ToString()));
+
+            bool shouldUpdateBuildSettings = false;
+            var configurationSceneGuids = configuration.BuildScenesCollection(buildTarget, false).Select(s => s.Guid);
+            foreach (var sceneGuid in configurationSceneGuids) {
+                if (buildSettingsSceneGuids.Contains(sceneGuid) == false) {
+                    string scenePath = AssetDatabase.GUIDToAssetPath(sceneGuid);
+                    if (string.IsNullOrEmpty(scenePath)) {
+                        Debug.LogWarning($"Scene with Guid: {sceneGuid} can't be added!");
+                        continue;
+                    }
+
+                    buildSettingsScenes.Add(new EditorBuildSettingsScene(scenePath, true));
+                    Debug.Log($"{BuildConfigurationSettingsValidator.TAG} Automatically added scene: {scenePath}");
+                    shouldUpdateBuildSettings = true;
+                }
+            }
+
+            if (shouldUpdateBuildSettings) {
+                EditorBuildSettings.scenes = buildSettingsScenes.ToArray();
+            }
+        }
+
+        static void ProcessPlatforms(ref List<AddressableSceneAsset> scenes, BuildTarget buildTarget, List<PlatformsConfiguration> platforms, bool stripAddressable)
+        {
+            foreach (var platformsConfiguration in platforms)
+            {
+                var editorBuildTargets = platformsConfiguration.GetBuildTargetsEditor();
+                if (editorBuildTargets.Contains(buildTarget)) {
+                    var platformScenes = stripAddressable ? platformsConfiguration.GetNonAddressableScenes()
+                                                                     : platformsConfiguration.Scenes;
+
+                    InsertScenes(ref scenes, platformScenes);
+                    break;
+                }
+            }
+        }
+
+        static void InsertScenes(ref List<AddressableSceneAsset> scenes, List<AddressableSceneAsset> sceneToInsert)
+        {
+            for (var index = 0; index < sceneToInsert.Count; index++)
+            {
+                var scene = sceneToInsert[index];
+                if (string.IsNullOrEmpty(scene.Guid))
+                    continue;
+
+                if (scenes.Contains(scene))
+                {
+                    scenes.Remove(scene);
+                }
+
+                scenes.Insert(index, scene);
+            }
         }
     }
 }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/PlatformsConfigurationExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/PlatformsConfigurationExtension.cs
@@ -11,9 +11,9 @@ namespace StansAssets.SceneManagement.Build
             return platformsConfiguration.Scenes.Where(scene => scene.GetSceneAsset() != null && scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
         }
 
-        public static List<SceneAsset> GetNonAddressableScenes(this PlatformsConfiguration platformsConfiguration)
+        public static List<AddressableSceneAsset> GetNonAddressableScenes(this PlatformsConfiguration platformsConfiguration)
         {
-            return platformsConfiguration.Scenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
+            return platformsConfiguration.Scenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable).ToList();
         }
 
         public static List<BuildTarget> GetBuildTargetsEditor(this PlatformsConfiguration platformsConfiguration)

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
@@ -15,6 +15,11 @@ namespace StansAssets.SceneManagement.Build
         public List<AddressableSceneAsset> DefaultScenes = new List<AddressableSceneAsset>();
         public List<PlatformsConfiguration> Platforms = new List<PlatformsConfiguration>();
 
+        Dictionary<string, AddressableSceneAsset> m_AddressableSceneNamesToSceneAssets;
+        [SerializeField] List<string> m_SceneNames = new List<string>();
+        [SerializeField] List<AddressableSceneAsset> m_SceneAssets = new List<AddressableSceneAsset>();
+        [SerializeField] List<string> m_AllSceneNames = new List<string>();
+
         public bool IsEmpty => DefaultScenes.Count == 0 && Platforms.Count == 0;
 
         internal BuildConfiguration Copy()
@@ -54,15 +59,16 @@ namespace StansAssets.SceneManagement.Build
             return false;
         }
 
-        Dictionary<string, AddressableSceneAsset> m_AddressableSceneNamesToSceneAssets;
-        [SerializeField] List<string> m_SceneNames = new List<string>();
-        [SerializeField] List<AddressableSceneAsset> m_SceneAssets = new List<AddressableSceneAsset>();
+        internal bool HasScene(string sceneName) {
+            return m_AllSceneNames.Contains(sceneName);
+        }
 
-        internal void SetScenesConfig(List<string> sceneNames, List<AddressableSceneAsset> sceneAssets)
+        internal void SetScenesConfig(List<string> addressableSceneNames, List<AddressableSceneAsset> addressableSceneAssets, List<string> allSceneNames)
         {
             m_AddressableSceneNamesToSceneAssets = null;
-            m_SceneNames = sceneNames;
-            m_SceneAssets = sceneAssets;
+            m_SceneNames = addressableSceneNames;
+            m_SceneAssets = addressableSceneAssets;
+            m_AllSceneNames = allSceneNames;
         }
 
         Dictionary<string, AddressableSceneAsset> AddressableSceneNamesToSceneAssets

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfigurationSettings.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfigurationSettings.cs
@@ -16,5 +16,16 @@ namespace StansAssets.SceneManagement.Build
         public BuildConfiguration Configuration => ActiveConfigurationIndex >= BuildConfigurations.Count
             ? new BuildConfiguration()
             : BuildConfigurations[ActiveConfigurationIndex];
+
+        internal bool HasValidConfiguration {
+            get {
+                foreach (var configuration in BuildConfigurations) {
+                    if (configuration.IsEmpty == false) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
     }
 }

--- a/com.stansassets.scene-management/Runtime/Statis/AdditiveScenesLoader.cs
+++ b/com.stansassets.scene-management/Runtime/Statis/AdditiveScenesLoader.cs
@@ -55,6 +55,11 @@ namespace StansAssets.SceneManagement
         /// </summary>
         public static IAsyncOperation LoadAdditively(string sceneName, Action<Scene> loadCompleted = null)
         {
+            if (ValidateScene(sceneName) == false) {
+                throw new ArgumentException($"Build Configuration doesn't contain scene: {sceneName}." +
+                    $"\nTo load a scene please add it to platform specific collection or Default scenes.");
+            }
+
             if (!Application.isEditor && IsSceneAddressable(sceneName))
             {
                 return LoadAddressableAdditively(sceneName, loadCompleted);
@@ -384,6 +389,13 @@ namespace StansAssets.SceneManagement
         static bool IsSceneAddressable(string sceneName)
         {
             return BuildConfigurationSettings.Instance.Configuration.IsSceneAddressable(sceneName);
+        }
+
+        static bool ValidateScene(string sceneName) {
+            if (BuildConfigurationSettings.Instance.HasValidConfiguration) {
+                return BuildConfigurationSettings.Instance.Configuration.HasScene(sceneName);
+            }
+            return SceneManager.GetSceneByName(sceneName).IsValid();
         }
     }
 


### PR DESCRIPTION
## Purpose of this PR
Added warnings on recompile when missing/duplicated scenes present in configuration (validator), red color UI when empty scene, many extensions for BuildConfigurtation class to unify the process of fetching scenes for a build, throw an exception when loads a scene that is not present in build configuration, minor fixes/updates

## Testing status
* No tests have been added.

## Comments to reviewers
Please carefully take a look at this code changes because I rushed it late Friday evening and maybe was drunk.
