### PR TITLE
fix: Validation empty scene management hot fixed

### DIFF
--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
@@ -20,7 +20,20 @@ namespace StansAssets.SceneManagement.Build
         [SerializeField] List<AddressableSceneAsset> m_SceneAssets = new List<AddressableSceneAsset>();
         [SerializeField] List<string> m_AllSceneNames = new List<string>();
 
-        public bool IsEmpty => DefaultScenes.Count == 0 && Platforms.Count == 0;
+        public bool IsEmpty
+        {
+            get
+            {
+                foreach (var platform in Platforms)
+                {
+                    if (platform.IsEmpty == false)
+                    {
+                        return false;
+                    }
+                }
+                return DefaultScenes.Count == 0;
+            }
+        }
 
         internal BuildConfiguration Copy()
         {

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/PlatformsConfiguration.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/PlatformsConfiguration.cs
@@ -11,5 +11,7 @@ namespace StansAssets.SceneManagement.Build
     {
         public List<BuildTargetRuntime> BuildTargets = new List<BuildTargetRuntime>();
         public List<AddressableSceneAsset> Scenes = new List<AddressableSceneAsset>();
+
+        public bool IsEmpty => BuildTargets.Count == 0 && Scenes.Count == 0;
     }
 }


### PR DESCRIPTION
## Purpose of this PR
Hotfix to prevent scene validation exception when build configuration is actually empty.

## Testing status
* No tests have been added.

### Manual testing status
Started a project from Landing successfully.

## Comments to reviewers
It's just a hotfix to make it work, but the proper solution should be integrated into UI and build configuration classes. So when you delete everything(BuildTargets and Scenes) from PlatformsConfiguration - we should delete this PlatformsConfiguration as well. But it stays empty and serialized there in a settings file.
