### PR TITLE
feat: added toggle option to clear addressables cache

### DIFF
--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -144,6 +144,8 @@ namespace StansAssets.SceneManagement.Build
             using (new IMGUIBlockWithIndent(new GUIContent("Addressables"))) {
                 conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor", conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
 
+                conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache", conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
+                
                 using (new IMGUIBeginHorizontal())
                 {
                     GUILayout.FlexibleSpace();

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
@@ -7,6 +7,7 @@ using UnityEditor.AddressableAssets;
 using UnityEditor.AddressableAssets.Build;
 using UnityEditor.AddressableAssets.Settings;
 using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+using UnityEditor.Build.Pipeline.Utilities;
 
 namespace StansAssets.SceneManagement.Build
 {
@@ -50,6 +51,7 @@ namespace StansAssets.SceneManagement.Build
                 handler.Invoke(options);
             }
 
+            PrebuildCleanup();
             SetupAddressableScenes(options.target);
             options.scenes = FilterScenesByPath(options.target, options.scenes);
 
@@ -149,6 +151,32 @@ namespace StansAssets.SceneManagement.Build
                 var entry = AddressableAssetSettingsDefaultObject.Settings.CreateOrMoveEntry(guid, group, false, true);
                 entry.address = scene.name;
             }
+        }
+
+        static void PrebuildCleanup()
+        {
+            RemoveMissingGroupReferences();
+            if (BuildConfigurationSettings.Instance.Configuration.ClearAllAddressablesCache)
+            {
+                ClearAllAddressablesCache();
+            }
+        }
+
+        static void RemoveMissingGroupReferences()
+        {
+            AddressableAssetSettings settings = AddressableAssetSettingsDefaultObject.Settings;
+            var groups = settings.groups;
+            var missingAddressableAssetGroups = groups.Where(g => g == null).ToList();
+            for (var i = 0; i < missingAddressableAssetGroups.Count; i++)
+            {
+                settings.RemoveGroup(missingAddressableAssetGroups[i]);
+            }
+        }
+
+        static void ClearAllAddressablesCache()
+        {
+            AddressableAssetSettings.CleanPlayerContent();
+            BuildCache.PurgeCache(true);
         }
     }
 

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
@@ -49,6 +49,25 @@ namespace StansAssets.SceneManagement.Build
 #endif
             }
         }
+        
+        internal bool ClearAllAddressablesCache
+        {
+            get
+            {
+#if UNITY_EDITOR
+                return UnityEditor.EditorPrefs.GetBool($"{Name}_user-clear-all-addressable-cache", true);
+#else
+                return true;
+#endif
+            }
+
+            set
+            {
+#if UNITY_EDITOR
+                UnityEditor.EditorPrefs.SetBool($"{Name}_user-clear-all-addressable-cache", value);
+#endif
+            }
+        }
 
         internal BuildConfiguration Copy()
         {

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildConfiguration.cs
@@ -55,9 +55,9 @@ namespace StansAssets.SceneManagement.Build
             get
             {
 #if UNITY_EDITOR
-                return UnityEditor.EditorPrefs.GetBool($"{Name}_user-clear-all-addressable-cache", true);
+                return UnityEditor.EditorPrefs.GetBool($"{Name}_user-clear-all-addressable-cache", false);
 #else
-                return true;
+                return false;
 #endif
             }
 


### PR DESCRIPTION
## Purpose of this PR
Added toggle option to clear Addressables cache in the user interface and associated functionality.
Added missing groups remove from AddressableAssetSettings on build preprocessor.

## Testing status 
* No tests have been added. 

### Manual testing status
Tested in the editor.
