### PR TITLE
feat: Editor mode scene check #10

### DIFF
--- a/com.stansassets.scene-management/Editor/Settings/SceneManagementSettings.cs
+++ b/com.stansassets.scene-management/Editor/Settings/SceneManagementSettings.cs
@@ -12,15 +12,35 @@ namespace StansAssets.SceneManagement
     {
         protected override bool IsEditorOnly => true;
         public override string PackageName => SceneManagementPackage.PackageName;
-        
+
 #if UNITY_2019_4_OR_NEWER
         public SceneAsset LandingScene;
         internal List<SceneStateInfo> OpenScenesBeforeLandingStart;
         internal int LastActiveSceneIndex;
         internal SceneViewInfo LastSceneView;
+
+        const string k_UseCameraAndScenePersistenceKey = "_use-camera-and-scene-persistency";
+
+        internal bool UseCameraAndScenePersistence
+        {
+            get
+            {
+#if UNITY_EDITOR
+                return EditorPrefs.GetBool($"{k_UseCameraAndScenePersistenceKey}", false);
+#else
+                return false;
 #endif
-        
-        
-        
+            }
+
+            set
+            {
+#if UNITY_EDITOR
+                EditorPrefs.SetBool($"{k_UseCameraAndScenePersistenceKey}", value);
+#endif
+            }
+        }
+
+#endif
+
     }
 }

--- a/com.stansassets.scene-management/Editor/Settings/StartLandingAction.cs
+++ b/com.stansassets.scene-management/Editor/Settings/StartLandingAction.cs
@@ -79,7 +79,8 @@ namespace StansAssets.SceneManagement
         {
             if (playModeStateChange == PlayModeStateChange.EnteredEditMode)
             {
-                if (SceneManagementSettings.Instance.OpenScenesBeforeLandingStart != null
+                if (SceneManagementSettings.Instance.UseCameraAndScenePersistence
+                    && SceneManagementSettings.Instance.OpenScenesBeforeLandingStart != null
                     && SceneManagementSettings.Instance.OpenScenesBeforeLandingStart.Count > 0)
                 {
                     int startIndex = 0;
@@ -111,7 +112,7 @@ namespace StansAssets.SceneManagement
                         EditorSceneManager.CloseScene(SceneManager.GetSceneAt(0), false);
 
                     var info = SceneManagementSettings.Instance.LastSceneView;
-                    if (info != null && ! info.IsDefault)
+                    if (info != null && !info.IsDefault)
                     {
                         SceneView.lastActiveSceneView.in2DMode = info.Is2D;
                         SceneView.lastActiveSceneView.LookAt(info.Pivot, info.Rotation, info.Size, info.IsOrtho);

--- a/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uss
+++ b/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uss
@@ -2,4 +2,23 @@
     flex-grow: 1;
 }
 
+.scene-persistence-visual-element {
+    flex-direction: row;
+    margin: 1px 3px;
+}
 
+.scene-persistence-label {
+    -unity-text-align: middle-left;
+}
+
+.scene-persistence-enum-field {
+    flex-shrink: 1;
+    align-items: center;
+    margin: 0;
+}
+
+.uniform-object-field .unity-base-field__label,
+.uniform-object-field .unity-base-field__input {
+    flex-shrink: 1;
+    min-width: 50%;
+}

--- a/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uss.meta
+++ b/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uss.meta
@@ -1,10 +1,11 @@
 fileFormatVersion: 2
-guid: 612876047d61d4ee0b61cbc10f676d29
+guid: 95245f8d05fd28449ba2366582552f30
 ScriptedImporter:
-  fileIDToRecycleName:
-    11400000: stylesheet
+  internalIDToNameTable: []
   externalObjects: {}
+  serializedVersion: 2
   userData: 
   assetBundleName: 
   assetBundleVariant: 
   script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uxml
+++ b/com.stansassets.scene-management/Editor/Window/Tabs/SettingsTab.uxml
@@ -1,9 +1,16 @@
-<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xmlns:sa="StansAssets.Foundation.UIElements">
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" 
+         xmlns:sa="StansAssets.Foundation.UIElements" editor-extension-mode="False">
+
     <sa:SettingsBlock label="Optional Settings">
-        <uie:ObjectField label="Landing Scene" name="landing-scene" />
+        <uie:ObjectField label="Landing Scene" name="landing-scene" class="uniform-object-field" />
+        <ui:VisualElement name="scene-persistence" class="uniform-object-field scene-persistence-visual-element">
+            <ui:Label text="Scene &amp; Camera Persistence" name="scene-persistence-label" class="unity-base-field__label scene-persistence-label" />
+            <uie:EnumField name="persistence-enum-field" class="scene-persistence-enum-field" />
+        </ui:VisualElement>
+    </sa:SettingsBlock>
+    
+    <sa:SettingsBlock label="Registered Stacks View">
+        <ui:VisualElement name="StackVisualizersRoot" />
     </sa:SettingsBlock>
 
-    <sa:SettingsBlock label="Registered Stacks View">
-        <ui:VisualElement name="StackVisualizersRoot"/>
-    </sa:SettingsBlock>
 </ui:UXML>


### PR DESCRIPTION
- Scenes from the Scene Manager UI can be synchronized and added to the editor's build settings.
- We throw an error if you try to load a scene that is not included in the scene manager on the current platform.
- And we have a new platform "Editor", which allows you to add and work with scenes only in the context of the Editor.