### PR TITLE
Synchronization of scenes in editor mode;

### DIFF
--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationMenu.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationMenu.cs
@@ -4,9 +4,17 @@ namespace StansAssets.SceneManagement.Build
 {
     public static class BuildConfigurationMenu
     {
+        private static BuildConfigurationWindow m_Window;
+
         [MenuItem(SceneManagementPackage.RootMenu + "Build Settings", false, 1)]
-        public static void OpenBuildSettings() {
-            BuildConfigurationWindow.ShowTowardsInspector("Build Conf");
+        public static void OpenBuildSettings()
+        {
+            if (m_Window == null)
+            {
+                m_Window = BuildConfigurationWindow.ShowTowardsInspector("Build Conf");
+            }
+
+            m_Window.Show();
         }
     }
 }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
@@ -14,11 +14,6 @@ namespace StansAssets.SceneManagement.Build
         static void OnPlayModeStateChanged(PlayModeStateChange state) {
             switch (state) {
                 case PlayModeStateChange.EnteredPlayMode:
-                    // TODO: Do we really need to sync scenes on play mode state changed?
-                    // if (BuildConfigurationSettings.Instance.HasValidConfiguration) {
-                    //     BuildConfigurationSettings.Instance.Configuration
-                    //         .SetupEditorSettings(EditorUserBuildSettings.activeBuildTarget, false);
-                    // }
                     break;
             }
         }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationSettingsValidator.cs
@@ -14,9 +14,11 @@ namespace StansAssets.SceneManagement.Build
         static void OnPlayModeStateChanged(PlayModeStateChange state) {
             switch (state) {
                 case PlayModeStateChange.EnteredPlayMode:
-                    if (BuildConfigurationSettings.Instance.HasValidConfiguration) {
-                        BuildConfigurationSettings.Instance.Configuration.SetupBuildSettings(EditorUserBuildSettings.activeBuildTarget);
-                    }
+                    // TODO: Do we really need to sync scenes on play mode state changed?
+                    // if (BuildConfigurationSettings.Instance.HasValidConfiguration) {
+                    //     BuildConfigurationSettings.Instance.Configuration
+                    //         .SetupEditorSettings(EditorUserBuildSettings.activeBuildTarget, false);
+                    // }
                     break;
             }
         }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -12,13 +12,14 @@ namespace StansAssets.SceneManagement.Build
             "projects settings defined scene will be added to the build. " +
             "When Defult Scenes have atleaest one scene defined, " +
             "project scenes are ignored and only scene defined in this configuration will be used.";
-        
+
         static readonly Color s_ErrorColor = new Color(1f, 0.8f, 0.0f);
         static readonly Color s_InactiveColor = new Color(1f, 0.8f, 0.0f);
         static readonly  GUIContent s_DuplicatesGUIContent = new GUIContent("","Scene is duplicated!");
         static readonly GUIContent s_EmptySceneGUIContent = new GUIContent("","Scene is empty! Please drop a scene or remove this element.");
 
-        [SerializeField] IMGUIHyperLabel m_AddButton;
+        [SerializeField]
+        IMGUIHyperLabel m_AddButton;
 
         bool m_ShowBuildIndex;
 
@@ -81,7 +82,7 @@ namespace StansAssets.SceneManagement.Build
             if (EditorGUI.EndChangeCheck())
             {
                 UpdateActiveConfUI();
-                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations){
+                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations) {
                     buildConfiguration.UpdateSceneNames();
                 }
                 BuildConfigurationSettings.Save();
@@ -142,12 +143,11 @@ namespace StansAssets.SceneManagement.Build
                 }
             }
 
-            using (new IMGUIBlockWithIndent(new GUIContent("Addressables")))
-            {
+            using (new IMGUIBlockWithIndent(new GUIContent("Addressables"))) {
                 conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor", conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
 
                 conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache", conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
-
+                
                 using (new IMGUIBeginHorizontal())
                 {
                     GUILayout.FlexibleSpace();
@@ -194,7 +194,7 @@ namespace StansAssets.SceneManagement.Build
                 DrawDefaultScenes(conf);
             }
         }
-        
+
         void DrawDefaultScenes(BuildConfiguration conf)
         {
             using (new IMGUIBlockWithIndent(new GUIContent("Default Scenes")))
@@ -230,8 +230,7 @@ namespace StansAssets.SceneManagement.Build
                                     using (new IMGUIBeginHorizontal())
                                     {
                                         GUILayout.Space(2);
-                                        bool delete = GUILayout.Button("-", EditorStyles.miniButton,
-                                            GUILayout.Width(18));
+                                        bool delete = GUILayout.Button("-", EditorStyles.miniButton, GUILayout.Width(18));
                                         if (delete)
                                         {
                                             conf.Platforms.Remove(platform);
@@ -248,15 +247,13 @@ namespace StansAssets.SceneManagement.Build
                                 {
                                     ReorderableListGUI.Title("Build Targets");
 
-                                    ReorderableListGUI.ListField(platform.BuildTargets, BuildTargetListItem,
-                                        DrawEmptyPlatform);
+                                    ReorderableListGUI.ListField(platform.BuildTargets, BuildTargetListItem, DrawEmptyPlatform);
                                 }
                                 EditorGUILayout.EndVertical();
 
                                 EditorGUILayout.BeginVertical(GUILayout.ExpandWidth(true));
                                 {
-                                    GUI.backgroundColor =
-                                        m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
+                                    GUI.backgroundColor = m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
                                     ReorderableListGUI.Title("Scenes");
                                     GUI.backgroundColor = Color.white;
 
@@ -403,10 +400,8 @@ namespace StansAssets.SceneManagement.Build
 
         static GUIContent AddressableGuiContent => s_AddressableGuiContent ?? (s_AddressableGuiContent = new GUIContent("", "Mark scene Addressable?\nIf true - scene will be added as Addressable asset into \"Scenes\" group, otherwise - scene will be added into build settings."));
 
-        public void AddItemsToMenu(GenericMenu menu)
-        {
-            menu.AddItem(new GUIContent("Add Build Settings Scenes to Default"), false, () =>
-            {
+        public void AddItemsToMenu(GenericMenu menu) {
+            menu.AddItem(new GUIContent("Add Build Settings Scenes to Default"), false, () => {
                 var conf = BuildConfigurationSettings.Instance.BuildConfigurations[m_SelectionIndex];
                 foreach (var scene in EditorBuildSettings.scenes)
                 {

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -324,7 +324,19 @@ namespace StansAssets.SceneManagement.Build
 
                 var sceneAsset = itemValue.GetSceneAsset();
                 var sceneWithError = sceneAsset == null || !sceneSynced;
-                GUI.color = sceneWithError ? s_ErrorColor : Color.white;
+               
+                if (sceneWithError)
+                {
+                    GUI.color = s_ErrorColor;
+                }
+                else if (!sceneSynced)
+                {
+                    GUI.color = EditorBuildSettingsValidator.OutOfSyncColor;
+                }
+                else
+                {
+                    GUI.color = Color.white;
+                }
 
                 EditorGUI.indentLevel = 0;
                 EditorGUI.BeginChangeCheck();
@@ -389,9 +401,7 @@ namespace StansAssets.SceneManagement.Build
 
         static GUIContent s_AddressableGuiContent;
 
-        static GUIContent AddressableGuiContent => s_AddressableGuiContent ?? (s_AddressableGuiContent =
-            new GUIContent("",
-                "Mark scene Addressable?\nIf true - scene will be added as Addressable asset into \"Scenes\" group, otherwise - scene will be added into build settings."));
+        static GUIContent AddressableGuiContent => s_AddressableGuiContent ?? (s_AddressableGuiContent = new GUIContent("", "Mark scene Addressable?\nIf true - scene will be added as Addressable asset into \"Scenes\" group, otherwise - scene will be added into build settings."));
 
         public void AddItemsToMenu(GenericMenu menu)
         {

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -9,16 +9,14 @@ namespace StansAssets.SceneManagement.Build
     class BuildConfigurationWindow : IMGUISettingsWindow<BuildConfigurationWindow>, IHasCustomMenu
     {
         const string k_DefaultScenesDescription = "If you are leaving the default scnese empty, " +
-                                                  "projects settings defined scene will be added to the build. " +
-                                                  "When Defult Scenes have atleaest one scene defined, " +
-                                                  "project scenes are ignored and only scene defined in this configuration will be used.";
+            "projects settings defined scene will be added to the build. " +
+            "When Defult Scenes have atleaest one scene defined, " +
+            "project scenes are ignored and only scene defined in this configuration will be used.";
         
         static readonly Color s_ErrorColor = new Color(1f, 0.8f, 0.0f);
         static readonly Color s_InactiveColor = new Color(1f, 0.8f, 0.0f);
-        static readonly GUIContent s_DuplicatesGUIContent = new GUIContent("", "Scene is duplicated!");
-
-        static readonly GUIContent s_EmptySceneGUIContent =
-            new GUIContent("", "Scene is empty! Please drop a scene or remove this element.");
+        static readonly  GUIContent s_DuplicatesGUIContent = new GUIContent("","Scene is duplicated!");
+        static readonly GUIContent s_EmptySceneGUIContent = new GUIContent("","Scene is empty! Please drop a scene or remove this element.");
 
         [SerializeField] IMGUIHyperLabel m_AddButton;
 
@@ -83,11 +81,9 @@ namespace StansAssets.SceneManagement.Build
             if (EditorGUI.EndChangeCheck())
             {
                 UpdateActiveConfUI();
-                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations)
-                {
+                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations){
                     buildConfiguration.UpdateSceneNames();
                 }
-
                 BuildConfigurationSettings.Save();
             }
         }
@@ -101,7 +97,10 @@ namespace StansAssets.SceneManagement.Build
 
             m_SelectionIndex = DrawTabs();
 
-            DrawScrollView(() => { DrawConfiguration(m_SelectionIndex); });
+            DrawScrollView(() =>
+            {
+                DrawConfiguration(m_SelectionIndex);
+            });
         }
 
         void DrawConfiguration(int index)
@@ -110,8 +109,7 @@ namespace StansAssets.SceneManagement.Build
             using (new IMGUIBlockWithIndent(new GUIContent("Settings")))
             {
                 conf.Name = IMGUILayout.TextField("Configuration Name:", conf.Name);
-                conf.DefaultScenesFirst = IMGUILayout.ToggleFiled("Default Scenes First", conf.DefaultScenesFirst,
-                    IMGUIToggleStyle.ToggleType.YesNo);
+                conf.DefaultScenesFirst = IMGUILayout.ToggleFiled("Default Scenes First", conf.DefaultScenesFirst, IMGUIToggleStyle.ToggleType.YesNo);
 
                 GUILayout.Space(EditorGUIUtility.singleLineHeight);
                 using (new IMGUIBeginHorizontal())
@@ -146,11 +144,9 @@ namespace StansAssets.SceneManagement.Build
 
             using (new IMGUIBlockWithIndent(new GUIContent("Addressables")))
             {
-                conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor",
-                    conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
+                conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor", conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
 
-                conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache",
-                    conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
+                conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache", conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
 
                 using (new IMGUIBeginHorizontal())
                 {

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -159,6 +159,30 @@ namespace StansAssets.SceneManagement.Build
                 }
             }
 
+            var needScenesSync = EditorBuildSettingsValidator.CompareScenesWithBuildSettings();
+            if (needScenesSync)
+            {
+                using (new IMGUIBlockWithIndent(new GUIContent("Editor & Build Settings")))
+                {
+                    EditorGUILayout.HelpBox(EditorBuildSettingsValidator.ScenesSyncDescription, MessageType.Warning);
+
+                    using (new IMGUIBeginHorizontal())
+                    {
+                        GUILayout.FlexibleSpace();
+
+                        var active = GUILayout.Button("Clear Build Settings & Sync", GUILayout.Width(240));
+                        if (active)
+                        {
+                            if (BuildConfigurationSettings.Instance.HasValidConfiguration)
+                            {
+                                BuildConfigurationSettings.Instance.Configuration.SetupEditorSettings(
+                                    EditorUserBuildSettings.activeBuildTarget, true);
+                            }
+                        }
+                    }
+                }
+            }
+
             if (conf.DefaultScenesFirst)
             {
                 DrawDefaultScenes(conf);
@@ -219,7 +243,7 @@ namespace StansAssets.SceneManagement.Build
                                 }
                                 EditorGUILayout.EndVertical();
 
-                                EditorGUILayout.BeginVertical(GUILayout.Width(235f));
+                                EditorGUILayout.BeginVertical(GUILayout.Width(150));
                                 {
                                     ReorderableListGUI.Title("Build Targets");
 
@@ -227,7 +251,7 @@ namespace StansAssets.SceneManagement.Build
                                 }
                                 EditorGUILayout.EndVertical();
 
-                                EditorGUILayout.BeginVertical();
+                                EditorGUILayout.BeginVertical(GUILayout.ExpandWidth(true));
                                 {
                                     GUI.backgroundColor = m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
                                     ReorderableListGUI.Title("Scenes");
@@ -292,8 +316,11 @@ namespace StansAssets.SceneManagement.Build
                     GUI.Label(sceneIndexRect, sceneIndex.ToString());
                 }
 
+                var sceneSynced = BuildConfigurationSettings.Instance.Configuration
+                    .CheckIntersectSceneWhBuildSettings(EditorUserBuildSettings.activeBuildTarget, itemValue.Guid);
+
                 var sceneAsset = itemValue.GetSceneAsset();
-                var sceneWithError = sceneAsset == null;
+                var sceneWithError = sceneAsset == null || !sceneSynced;
                 GUI.color = sceneWithError ? s_ErrorColor : Color.white;
 
                 EditorGUI.indentLevel = 0;

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -9,17 +9,18 @@ namespace StansAssets.SceneManagement.Build
     class BuildConfigurationWindow : IMGUISettingsWindow<BuildConfigurationWindow>, IHasCustomMenu
     {
         const string k_DefaultScenesDescription = "If you are leaving the default scnese empty, " +
-            "projects settings defined scene will be added to the build. " +
-            "When Defult Scenes have atleaest one scene defined, " +
-            "project scenes are ignored and only scene defined in this configuration will be used.";
-
+                                                  "projects settings defined scene will be added to the build. " +
+                                                  "When Defult Scenes have atleaest one scene defined, " +
+                                                  "project scenes are ignored and only scene defined in this configuration will be used.";
+        
         static readonly Color s_ErrorColor = new Color(1f, 0.8f, 0.0f);
         static readonly Color s_InactiveColor = new Color(1f, 0.8f, 0.0f);
-        static readonly  GUIContent s_DuplicatesGUIContent = new GUIContent("","Scene is duplicated!");
-        static readonly GUIContent s_EmptySceneGUIContent = new GUIContent("","Scene is empty! Please drop a scene or remove this element.");
+        static readonly GUIContent s_DuplicatesGUIContent = new GUIContent("", "Scene is duplicated!");
 
-        [SerializeField]
-        IMGUIHyperLabel m_AddButton;
+        static readonly GUIContent s_EmptySceneGUIContent =
+            new GUIContent("", "Scene is empty! Please drop a scene or remove this element.");
+
+        [SerializeField] IMGUIHyperLabel m_AddButton;
 
         bool m_ShowBuildIndex;
 
@@ -82,9 +83,11 @@ namespace StansAssets.SceneManagement.Build
             if (EditorGUI.EndChangeCheck())
             {
                 UpdateActiveConfUI();
-                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations) {
+                foreach (var buildConfiguration in BuildConfigurationSettings.Instance.BuildConfigurations)
+                {
                     buildConfiguration.UpdateSceneNames();
                 }
+
                 BuildConfigurationSettings.Save();
             }
         }
@@ -98,10 +101,7 @@ namespace StansAssets.SceneManagement.Build
 
             m_SelectionIndex = DrawTabs();
 
-            DrawScrollView(() =>
-            {
-                DrawConfiguration(m_SelectionIndex);
-            });
+            DrawScrollView(() => { DrawConfiguration(m_SelectionIndex); });
         }
 
         void DrawConfiguration(int index)
@@ -110,7 +110,8 @@ namespace StansAssets.SceneManagement.Build
             using (new IMGUIBlockWithIndent(new GUIContent("Settings")))
             {
                 conf.Name = IMGUILayout.TextField("Configuration Name:", conf.Name);
-                conf.DefaultScenesFirst = IMGUILayout.ToggleFiled("Default Scenes First", conf.DefaultScenesFirst, IMGUIToggleStyle.ToggleType.YesNo);
+                conf.DefaultScenesFirst = IMGUILayout.ToggleFiled("Default Scenes First", conf.DefaultScenesFirst,
+                    IMGUIToggleStyle.ToggleType.YesNo);
 
                 GUILayout.Space(EditorGUIUtility.singleLineHeight);
                 using (new IMGUIBeginHorizontal())
@@ -143,11 +144,14 @@ namespace StansAssets.SceneManagement.Build
                 }
             }
 
-            using (new IMGUIBlockWithIndent(new GUIContent("Addressables"))) {
-                conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor", conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
+            using (new IMGUIBlockWithIndent(new GUIContent("Addressables")))
+            {
+                conf.UseAddressablesInEditor = IMGUILayout.ToggleFiled("Use Addressables InEditor",
+                    conf.UseAddressablesInEditor, IMGUIToggleStyle.ToggleType.YesNo);
 
-                conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache", conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
-                
+                conf.ClearAllAddressablesCache = IMGUILayout.ToggleFiled("Clear All Addressables Cache",
+                    conf.ClearAllAddressablesCache, IMGUIToggleStyle.ToggleType.YesNo);
+
                 using (new IMGUIBeginHorizontal())
                 {
                     GUILayout.FlexibleSpace();
@@ -194,7 +198,7 @@ namespace StansAssets.SceneManagement.Build
                 DrawDefaultScenes(conf);
             }
         }
-
+        
         void DrawDefaultScenes(BuildConfiguration conf)
         {
             using (new IMGUIBlockWithIndent(new GUIContent("Default Scenes")))
@@ -230,7 +234,8 @@ namespace StansAssets.SceneManagement.Build
                                     using (new IMGUIBeginHorizontal())
                                     {
                                         GUILayout.Space(2);
-                                        bool delete = GUILayout.Button("-", EditorStyles.miniButton, GUILayout.Width(18));
+                                        bool delete = GUILayout.Button("-", EditorStyles.miniButton,
+                                            GUILayout.Width(18));
                                         if (delete)
                                         {
                                             conf.Platforms.Remove(platform);
@@ -247,13 +252,15 @@ namespace StansAssets.SceneManagement.Build
                                 {
                                     ReorderableListGUI.Title("Build Targets");
 
-                                    ReorderableListGUI.ListField(platform.BuildTargets, BuildTargetListItem, DrawEmptyPlatform);
+                                    ReorderableListGUI.ListField(platform.BuildTargets, BuildTargetListItem,
+                                        DrawEmptyPlatform);
                                 }
                                 EditorGUILayout.EndVertical();
 
                                 EditorGUILayout.BeginVertical(GUILayout.ExpandWidth(true));
                                 {
-                                    GUI.backgroundColor = m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
+                                    GUI.backgroundColor =
+                                        m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
                                     ReorderableListGUI.Title("Scenes");
                                     GUI.backgroundColor = Color.white;
 
@@ -386,10 +393,14 @@ namespace StansAssets.SceneManagement.Build
 
         static GUIContent s_AddressableGuiContent;
 
-        static GUIContent AddressableGuiContent => s_AddressableGuiContent ?? (s_AddressableGuiContent = new GUIContent("", "Mark scene Addressable?\nIf true - scene will be added as Addressable asset into \"Scenes\" group, otherwise - scene will be added into build settings."));
+        static GUIContent AddressableGuiContent => s_AddressableGuiContent ?? (s_AddressableGuiContent =
+            new GUIContent("",
+                "Mark scene Addressable?\nIf true - scene will be added as Addressable asset into \"Scenes\" group, otherwise - scene will be added into build settings."));
 
-        public void AddItemsToMenu(GenericMenu menu) {
-            menu.AddItem(new GUIContent("Add Build Settings Scenes to Default"), false, () => {
+        public void AddItemsToMenu(GenericMenu menu)
+        {
+            menu.AddItem(new GUIContent("Add Build Settings Scenes to Default"), false, () =>
+            {
                 var conf = BuildConfigurationSettings.Instance.BuildConfigurations[m_SelectionIndex];
                 foreach (var scene in EditorBuildSettings.scenes)
                 {

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildConfigurationWindow.cs
@@ -243,7 +243,7 @@ namespace StansAssets.SceneManagement.Build
                                 }
                                 EditorGUILayout.EndVertical();
 
-                                EditorGUILayout.BeginVertical(GUILayout.Width(150));
+                                EditorGUILayout.BeginVertical(GUILayout.Width(235f));
                                 {
                                     ReorderableListGUI.Title("Build Targets");
 
@@ -251,7 +251,7 @@ namespace StansAssets.SceneManagement.Build
                                 }
                                 EditorGUILayout.EndVertical();
 
-                                EditorGUILayout.BeginVertical(GUILayout.ExpandWidth(true));
+                                EditorGUILayout.BeginVertical();
                                 {
                                     GUI.backgroundColor = m_ShowBuildIndex ? GUI.skin.settings.selectionColor : Color.white;
                                     ReorderableListGUI.Title("Scenes");

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
@@ -74,7 +74,7 @@ namespace StansAssets.SceneManagement.Build
             }
 
             var configuration = BuildConfigurationSettings.Instance.Configuration;
-            var sceneAssets = configuration.BuildScenesCollection(target, true);
+            var sceneAssets = configuration.BuildScenesCollection(target, true, false);
             var scenes = sceneAssets.Select(s => AssetDatabase.GUIDToAssetPath(s.Guid)).ToArray();
             return scenes;
         }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/BuildScenesPreprocessor.cs
@@ -74,7 +74,7 @@ namespace StansAssets.SceneManagement.Build
             }
 
             var configuration = BuildConfigurationSettings.Instance.Configuration;
-            var sceneAssets = configuration.BuildScenesCollection(target, true, false);
+            var sceneAssets = configuration.BuildScenesCollection(new BuildScenesParams(target, true, false));
             var scenes = sceneAssets.Select(s => AssetDatabase.GUIDToAssetPath(s.Guid)).ToArray();
             return scenes;
         }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
@@ -6,12 +6,11 @@ namespace StansAssets.SceneManagement.Build
     [InitializeOnLoad]
     public class EditorBuildSettingsValidator
     {
-        public const string ScenesSyncDescription = "Scenes in the Scene Management do not match the scenes " +
-                                                    " in the Build Settings" +
-                                                    ", they may not work correctly in the editor!";
+        public const string ScenesSyncDescription = "Current Editor Build Settings are our of sync " +
+                                                    "with the Scene Management build configuration.";
 
-        private const string k_HintDescription= "Scenes can be synchronized through the " +
-                                                "'Scene Management -> Build Settings'.";
+        const string k_HintDescription= "Scenes can be synchronized through the " +
+                                        "'Scene Management -> Build Settings'.";
 
         public static bool CompareScenesWithBuildSettings()
         {

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
@@ -1,0 +1,40 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace StansAssets.SceneManagement.Build
+{
+    [InitializeOnLoad]
+    public class EditorBuildSettingsValidator
+    {
+        public const string ScenesSyncDescription = "Scenes in the Scene Management do not match the scenes " +
+                                                    " in the Build Settings" +
+                                                    ", they may not work correctly in the editor!";
+
+        private const string k_HintDescription= "Scenes can be synchronized through the " +
+                                                "'Scene Management -> Build Settings'.";
+
+        public static bool CompareScenesWithBuildSettings()
+        {
+            var needToSync = BuildConfigurationSettings.Instance.Configuration
+                .CheckIntersectScenesWhBuildSettings(EditorUserBuildSettings.activeBuildTarget);
+
+            return needToSync;
+        }
+
+        static EditorBuildSettingsValidator()
+        {
+            EditorBuildSettings.sceneListChanged += EditorBuildSettingsOnSceneListChanged;
+        }
+
+        private static void EditorBuildSettingsOnSceneListChanged()
+        {
+            if (!CompareScenesWithBuildSettings())
+            {
+                return;
+            }
+
+            BuildConfigurationMenu.OpenBuildSettings();
+            Debug.LogError($"{ScenesSyncDescription}\n* {k_HintDescription}");
+        }
+    }
+}

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs
@@ -12,6 +12,8 @@ namespace StansAssets.SceneManagement.Build
         const string k_HintDescription= "Scenes can be synchronized through the " +
                                         "'Scene Management -> Build Settings'.";
 
+        public static readonly Color OutOfSyncColor = new Color(0.93f, 0.39f, 0.32f);
+
         public static bool CompareScenesWithBuildSettings()
         {
             var needToSync = BuildConfigurationSettings.Instance.Configuration

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs.meta
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/EditorBuildSettingsValidator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4ed31590c1c344b08f1638577ed8c7de
+timeCreated: 1674645488

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
@@ -53,8 +53,12 @@ namespace StansAssets.SceneManagement.Build
         }
 
         public static IEnumerable<SceneAssetInfo> BuildScenesCollection(this BuildConfiguration configuration,
-            BuildTarget builtTarget, bool stripAddressables, bool includeEditorScene)
+            BuildScenesParams buildScenesParams)
         {
+            var builtTarget = buildScenesParams.BuiltTarget;
+            var stripAddressables = buildScenesParams.StripAddressables;
+            var includeEditorScene = buildScenesParams.IncludeEditorScene;
+            
             var scenes = new List<SceneAssetInfo>();
             var defaultSceneAssets = stripAddressables
                 ? configuration.DefaultScenes.Where(s => !s.Addressable).ToList()
@@ -121,7 +125,7 @@ namespace StansAssets.SceneManagement.Build
 
             bool shouldUpdateBuildSettings = false;
             var configurationSceneGuids =
-                configuration.BuildScenesCollection(buildTarget, false, false).Select(s => s.Guid);
+                configuration.BuildScenesCollection(new BuildScenesParams(buildTarget, false, false)).Select(s => s.Guid);
             foreach (var sceneGuid in configurationSceneGuids)
             {
                 if (buildSettingsSceneGuids.Contains(sceneGuid) == false)
@@ -159,7 +163,7 @@ namespace StansAssets.SceneManagement.Build
 
             bool shouldUpdateBuildSettings = false;
             var configurationSceneGuids =
-                configuration.BuildScenesCollection(buildTarget, false, true).Select(s => s.Guid);
+                configuration.BuildScenesCollection(new BuildScenesParams(buildTarget, false, true)).Select(s => s.Guid);
             foreach (var sceneGuid in configurationSceneGuids)
             {
                 if (buildSettingsSceneGuids.Contains(sceneGuid) == false)
@@ -241,7 +245,7 @@ namespace StansAssets.SceneManagement.Build
                 .ToList();
 
             var configurationSceneGuids = configuration
-                .BuildScenesCollection(buildTarget, false, true)
+                .BuildScenesCollection(new BuildScenesParams(buildTarget, false, true))
                 .Select(s => s.Guid.ToString())
                 .ToList();
 
@@ -255,7 +259,7 @@ namespace StansAssets.SceneManagement.Build
             BuildTarget buildTarget, string sceneGuid)
         {
             var configurationSceneGuids = configuration
-                .BuildScenesCollection(buildTarget, false, true)
+                .BuildScenesCollection(new BuildScenesParams(buildTarget, false, true))
                 .Select(s => s.Guid.ToString())
                 .ToList();
 
@@ -267,6 +271,25 @@ namespace StansAssets.SceneManagement.Build
 
             var synced = EditorBuildSettings.scenes.Any(i => i.guid.ToString().Equals(sceneGuid));
             return synced;
+        }
+    }
+
+    internal struct BuildScenesParams
+    {
+        internal readonly BuildTarget BuiltTarget; 
+        internal readonly bool StripAddressables;
+        
+        /// <summary>
+        /// Include in the collection the "Editor" platform scenes.
+        /// It is only needed to work in the editor, otherwise set to "false" to prepare the collection for build.
+        /// </summary>
+        internal readonly bool IncludeEditorScene;
+
+        public BuildScenesParams(BuildTarget builtTarget, bool stripAddressables, bool includeEditorScene)
+        {
+            BuiltTarget = builtTarget;
+            StripAddressables = stripAddressables;
+            IncludeEditorScene = includeEditorScene;
         }
     }
 }

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
@@ -52,10 +52,7 @@ namespace StansAssets.SceneManagement.Build
 
         public static IEnumerable<SceneAssetInfo> BuildScenesCollection(this BuildConfiguration configuration, BuildScenesParams buildScenesParams)
         {
-            var builtTarget = buildScenesParams.BuiltTarget;
             var stripAddressables = buildScenesParams.StripAddressables;
-            var includeEditorScene = buildScenesParams.IncludeEditorScene;
-            
             var scenes = new List<SceneAssetInfo>();
             var defaultSceneAssets = stripAddressables
                 ? configuration.DefaultScenes.Where(s => !s.Addressable).ToList()
@@ -63,13 +60,13 @@ namespace StansAssets.SceneManagement.Build
 
             if (configuration.DefaultScenesFirst)
             {
-                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables, includeEditorScene);
+                ProcessPlatforms(ref scenes, configuration.Platforms, buildScenesParams);
                 InsertScenes(ref scenes, defaultSceneAssets);
             }
             else
             {
                 InsertScenes(ref scenes, defaultSceneAssets);
-                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables, includeEditorScene);
+                ProcessPlatforms(ref scenes, configuration.Platforms, buildScenesParams);
             }
 
             return scenes;
@@ -182,9 +179,12 @@ namespace StansAssets.SceneManagement.Build
             }
         }
 
-        static void ProcessPlatforms(ref List<SceneAssetInfo> scenes, BuildTarget buildTarget,
-            List<PlatformsConfiguration> platforms, bool stripAddressable, bool includeEditorScene)
+        static void ProcessPlatforms(ref List<SceneAssetInfo> scenes, List<PlatformsConfiguration> platforms, BuildScenesParams buildScenesParams)
         {
+            var buildTarget = buildScenesParams.BuiltTarget;
+            var stripAddressable = buildScenesParams.StripAddressables;
+            var includeEditorScene = buildScenesParams.IncludeEditorScene;
+            
             foreach (var platformsConfiguration in platforms)
             {
                 var editorBuildTargets = platformsConfiguration.GetBuildTargetsEditor();

--- a/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Editor/Extensions/BuildConfigurationExtension.cs
@@ -10,14 +10,12 @@ namespace StansAssets.SceneManagement.Build
     {
         public static List<SceneAsset> GetAddressableDefaultScenes(this BuildConfiguration configuration)
         {
-            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && scene.Addressable)
-                .Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
+            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
         }
 
         public static List<SceneAsset> GetNonAddressableDefaultScenes(this BuildConfiguration configuration)
         {
-            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable)
-                .Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
+            return configuration.DefaultScenes.Where(scene => scene.GetSceneAsset() != null && !scene.Addressable).Select(addressableScene => addressableScene.GetSceneAsset()).ToList();
         }
 
         public static void InitializeBuildData(this BuildConfiguration buildConfiguration, BuildTarget buildTarget)
@@ -32,7 +30,7 @@ namespace StansAssets.SceneManagement.Build
         {
             foreach (var scene in buildConfiguration.DefaultScenes)
             {
-                if (scene == null)
+                if(scene == null)
                     continue;
 
                 var path = AssetDatabase.GUIDToAssetPath(scene.Guid);
@@ -43,7 +41,7 @@ namespace StansAssets.SceneManagement.Build
             {
                 foreach (var scene in platform.Scenes)
                 {
-                    if (scene == null)
+                    if(scene == null)
                         continue;
 
                     var path = AssetDatabase.GUIDToAssetPath(scene.Guid);
@@ -52,8 +50,7 @@ namespace StansAssets.SceneManagement.Build
             }
         }
 
-        public static IEnumerable<SceneAssetInfo> BuildScenesCollection(this BuildConfiguration configuration,
-            BuildScenesParams buildScenesParams)
+        public static IEnumerable<SceneAssetInfo> BuildScenesCollection(this BuildConfiguration configuration, BuildScenesParams buildScenesParams)
         {
             var builtTarget = buildScenesParams.BuiltTarget;
             var stripAddressables = buildScenesParams.StripAddressables;
@@ -66,22 +63,19 @@ namespace StansAssets.SceneManagement.Build
 
             if (configuration.DefaultScenesFirst)
             {
-                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables,
-                    includeEditorScene);
+                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables, includeEditorScene);
                 InsertScenes(ref scenes, defaultSceneAssets);
             }
             else
             {
                 InsertScenes(ref scenes, defaultSceneAssets);
-                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables,
-                    includeEditorScene);
+                ProcessPlatforms(ref scenes, builtTarget, configuration.Platforms, stripAddressables, includeEditorScene);
             }
 
             return scenes;
         }
 
-        public static bool IsActive(this BuildConfiguration configuration,
-            PlatformsConfiguration platformsConfiguration)
+        public static bool IsActive(this BuildConfiguration configuration, PlatformsConfiguration platformsConfiguration)
         {
             BuildTargetRuntime buildTarget = (BuildTargetRuntime)(int)EditorUserBuildSettings.activeBuildTarget;
             return platformsConfiguration.BuildTargets.Contains(buildTarget);
@@ -97,9 +91,7 @@ namespace StansAssets.SceneManagement.Build
                     var platformIndex = platformConfiguration.Scenes.IndexOf(scene);
                     if (platformIndex >= 0)
                     {
-                        return configuration.DefaultScenesFirst
-                            ? configuration.DefaultScenes.Count + platformIndex
-                            : platformIndex;
+                        return configuration.DefaultScenesFirst ? configuration.DefaultScenes.Count + platformIndex : platformIndex;
                     }
 
                     platformScenesCount = platformConfiguration.Scenes.Count;
@@ -124,8 +116,7 @@ namespace StansAssets.SceneManagement.Build
             var buildSettingsSceneGuids = new HashSet<string>(buildSettingsScenes.Select(s => s.guid.ToString()));
 
             bool shouldUpdateBuildSettings = false;
-            var configurationSceneGuids =
-                configuration.BuildScenesCollection(new BuildScenesParams(buildTarget, false, false)).Select(s => s.Guid);
+            var configurationSceneGuids = configuration.BuildScenesCollection(new BuildScenesParams(buildTarget, false, false)).Select(s => s.Guid);
             foreach (var sceneGuid in configurationSceneGuids)
             {
                 if (buildSettingsSceneGuids.Contains(sceneGuid) == false)
@@ -212,7 +203,6 @@ namespace StansAssets.SceneManagement.Build
                 }
             }
         }
-
 
         static void InsertScenes(ref List<SceneAssetInfo> scenes, List<SceneAssetInfo> sceneToInsert)
         {

--- a/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildTargetRuntime.cs
+++ b/com.stansassets.scene-management/BuildConfigurator/Runtime/BuildTargetRuntime.cs
@@ -98,5 +98,6 @@ namespace StansAssets.SceneManagement.Build
         /// </summary>
         Switch = 38, // 0x00000026
         Lumin = 39, // 0x00000027
+        Editor = 1242023, // No listed in 'UnityEditor.BuildTarget'!
     }
 }


### PR DESCRIPTION
- Scenes from the Scene Manager UI can be synchronized and added to the editor's build settings.
- We throw an error if you try to load a scene that is not included in the scene manager on the current platform.
- And we have a new platform "Editor", which allows you to add and work with scenes only in the context of the Editor.